### PR TITLE
Added IoT-based air pollution dataset for Dhaka (2017–2022)

### DIFF
--- a/src/data/air-pollution-data/about the data.md
+++ b/src/data/air-pollution-data/about the data.md
@@ -1,0 +1,57 @@
+This dataset contains real-time air pollution data collected in Dhaka, Bangladesh using IoT-enabled sensors. The monitoring system was designed to measure key air quality parameters continuously, helping in environmental research and decision-making processes.
+
+Data Collection Method:
+IoT sensors connected via Arduino IDE for real-time monitoring
+
+Data logged using Excel Data Streamer
+
+Data saved in a structured CSV format for analysis
+
+Sensors recorded levels of:
+
+Sulfur Dioxide (SO₂)
+
+Nitrogen Dioxide (NO₂)
+
+Carbon Monoxide (CO)
+
+Ozone (O₃)
+
+Particulate Matter 2.5 (PM2.5)
+
+Particulate Matter 10 (PM10)
+
+Coverage:
+Location: Dhaka, Bangladesh
+
+Date Range: January 1, 2017 – December 31, 2022
+
+Total Records: 155,405 rows
+
+File Size: 14.6 MB
+
+Format: CSV (my_ap_dataset.csv)
+
+Dataset Fields:
+Date
+
+Station code
+
+Address
+
+Latitude
+
+Longitude
+
+SO₂
+
+NO₂
+
+CO
+
+O₃
+
+PM2.5
+
+PM10
+


### PR DESCRIPTION
This dataset contains real-time air pollution data collected in Dhaka, Bangladesh using IoT-enabled sensors. The monitoring system was designed to measure key air quality parameters continuously, helping in environmental research and decision-making processes.

Data Collection Method:
IoT sensors connected via Arduino IDE for real-time monitoring

Data logged using Excel Data Streamer

Data saved in a structured CSV format for analysis

Sensors recorded levels of:

Sulfur Dioxide (SO₂)

Nitrogen Dioxide (NO₂)

Carbon Monoxide (CO)

Ozone (O₃)

Particulate Matter 2.5 (PM2.5)

Particulate Matter 10 (PM10)

Coverage:
Location: Dhaka, Bangladesh

Date Range: January 1, 2017 – December 31, 2022

Total Records: 155,405 rows

File Size: 14.6 MB

Format: CSV (my_ap_dataset.csv)

Dataset Fields:
Date

Station code

Address

Latitude

Longitude

SO₂

NO₂

CO

O₃

PM2.5

PM10

